### PR TITLE
improve CPU usage by adding time.Sleep in consume func

### DIFF
--- a/event/consumer.go
+++ b/event/consumer.go
@@ -2,10 +2,16 @@ package event
 
 import (
 	"context"
+	"time"
 
 	kafka "github.com/ONSdigital/dp-kafka/v3"
 	"github.com/ONSdigital/dp-search-reindex-tracker/config"
 	"github.com/ONSdigital/log.go/v2/log"
+)
+
+const (
+	// ensure KAFKA_CONSUME_WAIT_TIME is significantly less than the graceful shutdown timeout
+	KAFKA_CONSUME_WAIT_TIME = 1 * time.Second
 )
 
 // Consume converts messages to event instances, and pass the event to the provided handler.
@@ -25,6 +31,8 @@ func Consume[M KafkaAvroModel](ctx context.Context, cfg *config.Config, topicEve
 			case <-topicEvent.ConsumerGroup.Channels().Closer:
 				log.Info(ctx, "closing event consumer loop because closer channel is closed", log.Data{"worker_id": workerID})
 				return
+			default:
+				time.Sleep(KAFKA_CONSUME_WAIT_TIME)
 			}
 		}
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -58,7 +58,7 @@ func Run(ctx context.Context, serviceList *ExternalServiceList, buildTime, gitCo
 		return nil, err
 	}
 
-	// Start 'Reindex Requested' Kafka Consumer
+	// Get 'Reindex Requested' kafka information for handling
 	reindexRequestedEventOptions := &event.KafkaEventOptions{
 		ConsumerGroup:          reindexRequestedConsumer,
 		SearchReindexAPIClient: searchReindexAPIClient,
@@ -68,15 +68,8 @@ func Run(ctx context.Context, serviceList *ExternalServiceList, buildTime, gitCo
 		log.Fatal(ctx, "failed to get reindex requested event", err)
 		return nil, err
 	}
-	event.Consume(ctx, cfg, reindexRequestedEvent)
 
-	if consumerStartErr := reindexRequestedConsumer.Start(); consumerStartErr != nil {
-		log.Fatal(ctx, "error starting the reindex requested consumer", consumerStartErr)
-		return nil, consumerStartErr
-	}
-	reindexRequestedConsumer.LogErrors(ctx)
-
-	// Start 'Reindex Task Counts' Kafka Consumer
+	// Get 'Reindex Task Counts' kafka information for handling
 	reindexTaskCountsEventOptions := &event.KafkaEventOptions{
 		ConsumerGroup: reindexTaskCountsConsumer,
 	}
@@ -85,15 +78,8 @@ func Run(ctx context.Context, serviceList *ExternalServiceList, buildTime, gitCo
 		log.Fatal(ctx, "failed to get reindex task counts event", err)
 		return nil, err
 	}
-	event.Consume(ctx, cfg, reindexTaskCountsEvent)
 
-	if consumerStartErr := reindexTaskCountsConsumer.Start(); consumerStartErr != nil {
-		log.Fatal(ctx, "error starting the reindex task counts consumer", consumerStartErr)
-		return nil, consumerStartErr
-	}
-	reindexTaskCountsConsumer.LogErrors(ctx)
-
-	// Start 'Search Data Imported' Kafka Consumer
+	// Get 'Search Data Imported' kafka information for handling
 	searchDataImportedEventOptions := &event.KafkaEventOptions{
 		ConsumerGroup: searchDataImportedConsumer,
 	}
@@ -102,13 +88,30 @@ func Run(ctx context.Context, serviceList *ExternalServiceList, buildTime, gitCo
 		log.Fatal(ctx, "failed to get search data imported event", err)
 		return nil, err
 	}
+
+	// Kafka error logging go-routine
+	reindexRequestedConsumer.LogErrors(ctx)
+	reindexTaskCountsConsumer.LogErrors(ctx)
+	searchDataImportedConsumer.LogErrors(ctx)
+
+	// Start consuming events
+	event.Consume(ctx, cfg, reindexRequestedEvent)
+	event.Consume(ctx, cfg, reindexTaskCountsEvent)
 	event.Consume(ctx, cfg, searchDataImportedEvent)
 
+	// Start kafka consumers
+	if consumerStartErr := reindexRequestedConsumer.Start(); consumerStartErr != nil {
+		log.Fatal(ctx, "error starting the reindex requested consumer", consumerStartErr)
+		return nil, consumerStartErr
+	}
+	if consumerStartErr := reindexTaskCountsConsumer.Start(); consumerStartErr != nil {
+		log.Fatal(ctx, "error starting the reindex task counts consumer", consumerStartErr)
+		return nil, consumerStartErr
+	}
 	if consumerStartErr := searchDataImportedConsumer.Start(); consumerStartErr != nil {
 		log.Fatal(ctx, "error starting the search data imported consumer", consumerStartErr)
 		return nil, consumerStartErr
 	}
-	searchDataImportedConsumer.LogErrors(ctx)
 
 	// Get HealthCheck
 	hc, err := serviceList.GetHealthCheck(cfg, buildTime, gitCommit, version)
@@ -161,9 +164,9 @@ func (svc *Service) Close(ctx context.Context) error {
 			svc.healthCheck.Stop()
 		}
 
-		// If reindexRequestedConsumer exists, stop listening to it.
+		// If kafka consumers exists, stop listening to it.
 		// This will automatically stop the event consumer loops and no more messages will be processed.
-		// The kafka reindexRequestedConsumer will be closed after the service shuts down.
+		// The kafka consumers will be closed after the service shuts down.
 		if svc.serviceList.KafkaConsumers {
 			log.Info(ctx, "stopping reindex requested consumer listener")
 			if err := svc.reindexRequestedConsumer.Stop(); err != nil {
@@ -171,12 +174,14 @@ func (svc *Service) Close(ctx context.Context) error {
 				hasShutdownError = true
 			}
 			log.Info(ctx, "stopped reindex requested consumer listener")
+
 			log.Info(ctx, "stopping reindex task counts consumer listener")
 			if err := svc.reindexTaskCountsConsumer.Stop(); err != nil {
 				log.Error(ctx, "error stopping reindex task counts consumer listener", err)
 				hasShutdownError = true
 			}
 			log.Info(ctx, "stopped reindex task counts consumer listener")
+
 			log.Info(ctx, "stopping search data imported consumer listener")
 			if err := svc.searchDataImportedConsumer.Stop(); err != nil {
 				log.Error(ctx, "error stopping search data imported consumer listener", err)
@@ -199,12 +204,14 @@ func (svc *Service) Close(ctx context.Context) error {
 				hasShutdownError = true
 			}
 			log.Info(ctx, "closed reindex requested consumer")
+
 			log.Info(ctx, "closing reindex task counts consumer")
 			if err := svc.reindexTaskCountsConsumer.Close(ctx); err != nil {
 				log.Error(ctx, "error closing reindex task counts consumer", err)
 				hasShutdownError = true
 			}
 			log.Info(ctx, "closed reindex task counts consumer")
+
 			log.Info(ctx, "closing search data imported consumer")
 			if err := svc.searchDataImportedConsumer.Close(ctx); err != nil {
 				log.Error(ctx, "error closing search data imported consumer", err)
@@ -258,7 +265,7 @@ func registerCheckers(ctx context.Context,
 	}
 
 	if hasErrors {
-		return errors.New("Error(s) registering checkers for healthcheck")
+		return errors.New("error(s) registering checkers for healthcheck")
 	}
 	return nil
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -155,7 +155,7 @@ func TestRun(t *testing.T) {
 
 		Convey("Given that Checkers cannot be registered", func() {
 
-			errAddheckFail := errors.New("Error(s) registering checkers for healthcheck")
+			errAddheckFail := errors.New("error(s) registering checkers for healthcheck")
 			hcMockAddFail := &serviceMock.HealthCheckerMock{
 				AddCheckFunc: func(name string, checker healthcheck.Checker) error { return errAddheckFail },
 				StartFunc:    func(ctx context.Context) {},


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- In the `consume` func, there is an infinite for loop happening which checks if a message has been received or if the consumer channel has been closed. Adding a sleep time by default (if both don't happen), reduces the rate of the loop. 
- This will reduce the CPU usage by a little amount only
- Other event-driven apps (such as the dp-import-tracker) also amount to high CPU usage indicating that the dp-kafka library can be improved in performance

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone