### PR TITLE
Consumes messages from reindex-task-counts

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -63,8 +63,10 @@ func GetReindexTaskCounts(options *KafkaEventOptions) (*KafkaConsumerEvent[Reind
 	}
 
 	topic := KafkaConsumerEvent[ReindexTaskCountsModel]{
-		Handler: &ReindexTaskCountsHandler{},
-		Schema:  ReindexTaskCountsSchema,
+		Handler: &ReindexTaskCountsHandler{
+			SearchReindexAPIClient: options.SearchReindexAPIClient,
+		},
+		Schema: ReindexTaskCountsSchema,
 	}
 
 	topic.ConsumerGroup = options.ConsumerGroup

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -124,7 +124,8 @@ func TestGetReindexRequested(t *testing.T) {
 func TestGetReindexTaskCounts(t *testing.T) {
 	Convey("Given valid options for reindex task counts event", t, func() {
 		options := &KafkaEventOptions{
-			ConsumerGroup: &kafkatest.IConsumerGroupMock{},
+			ConsumerGroup:          &kafkatest.IConsumerGroupMock{},
+			SearchReindexAPIClient: &searchReindexAPIMock.ClientMock{},
 		}
 
 		Convey("When GetReindexTaskCounts is called", func() {
@@ -134,7 +135,9 @@ func TestGetReindexTaskCounts(t *testing.T) {
 				So(event, ShouldNotBeNil)
 				So(event, ShouldNotBeEmpty)
 
-				So(event.Handler, ShouldResemble, &ReindexTaskCountsHandler{})
+				So(event.Handler, ShouldResemble, &ReindexTaskCountsHandler{
+					SearchReindexAPIClient: options.SearchReindexAPIClient,
+				})
 				So(event.Schema, ShouldResemble, ReindexTaskCountsSchema)
 				So(event.ConsumerGroup, ShouldResemble, options.ConsumerGroup)
 

--- a/event/handler_test.go
+++ b/event/handler_test.go
@@ -17,6 +17,10 @@ var (
 		SearchIndex: "testing",
 		TraceID:     "5678",
 	}
+	testReindexTaskCountEventOK = &ReindexTaskCountsModel{
+		JobID:   "1234",
+		TraceID: "5678",
+	}
 	errUnexpected = errors.New("unexpected error")
 )
 
@@ -83,14 +87,52 @@ func TestReindexRequestedHandler_Handle(t *testing.T) {
 	})
 }
 
-// TODO - complete unit test once ReindexTaskCountsHandler.Handle has been implemented
 func TestReindexTaskCountsHandler_Handle(t *testing.T) {
-	Convey("Given a successful event handler, when Handle is triggered", t, func() {
-		t.SkipNow()
+	ctx := context.Background()
+
+	cfg, err := config.Get()
+	if err != nil {
+		t.Errorf("failed to get config - err: %v", err)
+	}
+
+	Convey("Given post request to search reindex api is not successful", t, func() {
+		searchReindexAPIMock := &searchReindexAPIMock.ClientMock{
+			PatchJobFunc: func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (*sdk.RespHeaders, error) {
+				return nil, nil
+			},
+			PutTaskNumberOfDocsFunc: func(ctx context.Context, reqHeaders sdk.Headers, jobID string, taskName string, docCount string) (*sdk.RespHeaders, error) {
+				return nil, errUnexpected
+			},
+		}
+
+		reindexTaskCountHandler := &ReindexTaskCountsHandler{
+			SearchReindexAPIClient: searchReindexAPIMock,
+		}
+
+		Convey("When ReindexTaskCountHandler.Handle is called", func() {
+			err := reindexTaskCountHandler.Handle(ctx, cfg, testReindexTaskCountEventOK)
+			So(err, ShouldNotBeNil)
+		})
 	})
 
-	Convey("handler returns an error", t, func() {
-		t.SkipNow()
+	Convey("Given request to search reindex api is successful", t, func() {
+		searchReindexAPIMock := &searchReindexAPIMock.ClientMock{
+			PatchJobFunc: func(ctx context.Context, headers sdk.Headers, jobID string, body []sdk.PatchOperation) (*sdk.RespHeaders, error) {
+				return nil, nil
+			},
+			PutTaskNumberOfDocsFunc: func(ctx context.Context, reqHeaders sdk.Headers, jobID string, taskName string, docCount string) (*sdk.RespHeaders, error) {
+				return nil, nil
+			},
+		}
+
+		reindexTaskCountHandler := &ReindexTaskCountsHandler{
+			SearchReindexAPIClient: searchReindexAPIMock,
+		}
+
+		Convey("When ReindexTaskCountHandler.Handle is called", func() {
+			err := reindexTaskCountHandler.Handle(ctx, cfg, testReindexTaskCountEventOK)
+			So(err, ShouldBeNil)
+		})
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ONSdigital/dp-kafka/v3 v3.4.0
 	github.com/ONSdigital/dp-net v1.5.0
 	github.com/ONSdigital/dp-net/v2 v2.5.0-beta.2
-	github.com/ONSdigital/dp-search-reindex-api v0.23.0
+	github.com/ONSdigital/dp-search-reindex-api v0.24.0
 	github.com/ONSdigital/go-ns v0.0.0-20210916104633-ac1c1c52327e
 	github.com/ONSdigital/log.go/v2 v2.3.0-beta
 	github.com/cucumber/godog v0.12.5
@@ -87,6 +87,6 @@ require (
 	golang.org/x/net v0.0.0-20220920203100-d0c6ba3f52d9 // indirect
 	golang.org/x/sync v0.0.0-20220907140024-f12130a52804 // indirect
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/text v0.3.8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/ONSdigital/dp-net/v2 v2.5.0-beta.2 h1:I3XMUHQaq9nyzRq/teqQO6bZvb9g6Ac
 github.com/ONSdigital/dp-net/v2 v2.5.0-beta.2/go.mod h1:exhi6j2y2a9XQ7DKNZ1nnLlnEDL3usAp0DGB5X3/Yqo=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
-github.com/ONSdigital/dp-search-reindex-api v0.23.0 h1:c+PAOfxOIGh2GmDh2aBZjXJoPFRabF2tE5PUQwO9NcE=
-github.com/ONSdigital/dp-search-reindex-api v0.23.0/go.mod h1:MJTZN5wyvqKdQjQfuVgoPXAcMhabDbvoKzeQMRF0tSY=
+github.com/ONSdigital/dp-search-reindex-api v0.24.0 h1:TaUYtRP0aaXdIJ5ljnja111wKkfYpTfUfQAPfho1ni4=
+github.com/ONSdigital/dp-search-reindex-api v0.24.0/go.mod h1:lFqCcgkrkBfi1wDhWg4MIxhGec6wsKHTG/0wDUHDt4s=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/go-ns v0.0.0-20210916104633-ac1c1c52327e h1:o+AK5m0lxRIFn4t9ng9x19kez72ErAB0cW9ArT6sAZM=
 github.com/ONSdigital/go-ns v0.0.0-20210916104633-ac1c1c52327e/go.mod h1:BCx4ULp5nT3dT7Mft5iMrp9439JG9lqIlc0JOPmsHTg=
@@ -81,7 +81,6 @@ github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHB
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=
 github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
-github.com/ONSdigital/log.go v1.1.0 h1:XFE8U5lPeiXyujgUtbh+pKCotiICeIGFEAauNk9c24A=
 github.com/ONSdigital/log.go v1.1.0/go.mod h1:0hOVuYR3bDUI30VRo48d5KHfJIoe+spuPXqgt6UF78o=
 github.com/ONSdigital/log.go/v2 v2.0.0/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
 github.com/ONSdigital/log.go/v2 v2.0.5/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
@@ -372,7 +371,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
-github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.16 h1:kQPfno+wyx6C5572ABwV+Uo3pDFzQ7yhyGchSyRda0c=
 github.com/pierrec/lz4/v4 v4.1.16/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
@@ -646,8 +644,9 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
+golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
### What

The search reindex tracker will need to consume events from `reindex-task-counts` and make a request to search reindex API to update the task counts against a given reindex job.

- Consume message from `reindex-task-counts`
- When a message is received, make a request to update the task count for the task for a particular job via search reindex API
  - Endpoint to hit: `/jobs/<job_id>/tasks/<task_name>`
  - Use search reindex client
  - must go via api router (for audit purposes)
- Send a second request to update the total count against job, this should be using Patch method on `/jobs`

### How to review

Please check if the changes make sense

### Who can review

Anyone except me
